### PR TITLE
fix: adds shebang to support the documented usage via npx

### DIFF
--- a/mcp-server-ts/src/index.ts
+++ b/mcp-server-ts/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { registerAllTools, initializeSocket } from "./tools/index.js";


### PR DESCRIPTION
I got this by using the documented mcp configuration:

```
The published package is broken — it's missing the shebang (#!/usr/bin/env node) and
  ships uncompiled TypeScript/ESM. Let me check:                                        
                                                                                        
  Read 1 file (ctrl+o to expand)                                                        
                                                                                        
⏺ Missing #!/usr/bin/env node shebang. The fix is to run it with node explicitly. Update
   .mcp.json:
```