### PR TITLE
fix: keep one socket per connect so multi-chunk responses resolve

### DIFF
--- a/mcp-server-ts/package.json
+++ b/mcp-server-ts/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "build": "tsc && node -e \"require('fs').chmodSync('build/index.js', 0o755)\"",
-    "test": "node test/smoke-test.mjs",
+    "test": "node test/smoke-test.mjs && node test/reconnect-test.mjs",
     "prepublishOnly": "npm run build && npm test"
   },
   "engines": {

--- a/mcp-server-ts/src/tools/client.ts
+++ b/mcp-server-ts/src/tools/client.ts
@@ -35,6 +35,7 @@ export class TauriSocketClient {
   private reconnectAttempts = 0;
   private authToken: string | undefined;
   private suppressAutoReconnect = false;
+  private connectPromise: Promise<void> | null = null;
 
   constructor(config?: ConnectionConfig) {
     // Default to IPC with default path
@@ -95,6 +96,21 @@ export class TauriSocketClient {
   async connect(): Promise<void> {
     if (this.isConnected) return;
 
+    // An auto-reconnect and an outgoing command can both call connect() while
+    // there is no connection. Share the in-flight attempt so only one socket
+    // is ever created: two sockets would leave one of them carrying both data
+    // listeners, which doubles every chunk in the shared buffer.
+    if (this.connectPromise) return this.connectPromise;
+
+    this.connectPromise = this.openConnection();
+    try {
+      await this.connectPromise;
+    } finally {
+      this.connectPromise = null;
+    }
+  }
+
+  private openConnection(): Promise<void> {
     // Re-resolve auth token on every connect attempt so that tokens
     // written after MCP startup (e.g. by a Tauri app starting later)
     // are picked up without restarting the MCP process.
@@ -120,28 +136,47 @@ export class TauriSocketClient {
 
       console.error(`Connecting to ${connectionInfo} (attempt ${this.reconnectAttempts + 1})`);
       
-      this.client = net.createConnection(connectionOptions, () => {
+      const socket = net.createConnection(connectionOptions, () => {
         this.isConnected = true;
         this.reconnectAttempts = 0;
         console.error(`Connected to Tauri socket server at ${connectionInfo}`);
-        
-        // Setup data handler
-        this.client!.on('data', (data) => {
-          this.handleData(data);
-        });
-        
         resolve();
       });
+      this.client = socket;
 
-      this.client!.on('error', (err) => {
+      // Every listener binds to the socket this call created, never to
+      // this.client, which a later connect() may have replaced.
+      socket.on('data', (data) => {
+        this.handleData(data);
+      });
+
+      socket.on('error', (err) => {
         console.error('Socket connection error:', err);
-        this.isConnected = false;
+        if (this.client === socket) {
+          this.isConnected = false;
+        }
         reject(err);
       });
-      
-      this.client!.on('close', () => {
-        this.isConnected = false;
+
+      socket.on('close', () => {
         console.error('Socket connection closed');
+        socket.removeAllListeners();
+
+        // A socket that has already been replaced must not touch shared state
+        // or start a reconnect on behalf of the live connection.
+        if (this.client !== socket) return;
+
+        this.client = null;
+        this.isConnected = false;
+        // Drop any partial response: the rest of it is never arriving.
+        this.buffer = '';
+
+        // Nothing can answer a request that was in flight on this socket, so
+        // fail it now rather than leaving the caller to hit its own timeout.
+        for (const [id, callback] of this.responseCallbacks.entries()) {
+          this.responseCallbacks.delete(id);
+          callback.reject(new Error('Socket connection closed before a response arrived'));
+        }
 
         // Skip auto-reconnect if a managed reconnection (e.g. restart) is in progress
         if (this.suppressAutoReconnect) {
@@ -331,6 +366,9 @@ export class TauriSocketClient {
     }
     this.isConnected = false;
     this.buffer = '';
+    // The torn-down socket can no longer settle an in-flight connect attempt,
+    // so drop it and let the poll below start a fresh one.
+    this.connectPromise = null;
 
     // Poll for reconnection
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {

--- a/mcp-server-ts/src/tools/restart_app.ts
+++ b/mcp-server-ts/src/tools/restart_app.ts
@@ -107,7 +107,10 @@ export function registerRestartAppTool(server: McpServer) {
           // healthy process.
           const undeliverable = gracefulMessage.includes('timed out')
             || gracefulMessage.includes('Failed to connect')
-            || gracefulMessage.includes('Failed to send request');
+            || gracefulMessage.includes('Failed to send request')
+            // The app closed the socket before answering, e.g. it restarted
+            // faster than delay_ms. No response means nothing was refused.
+            || gracefulMessage.includes('Socket connection closed');
           if (!undeliverable) {
             return createErrorResponse(`Restart refused by the app: ${gracefulMessage}`);
           }

--- a/mcp-server-ts/test/reconnect-test.mjs
+++ b/mcp-server-ts/test/reconnect-test.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+/**
+ * Socket client reconnect regression test
+ *
+ * Stands up a fake newline-delimited JSON server and drives TauriSocketClient
+ * against it. Checks that overlapping connect() calls and reconnects leave
+ * exactly one connection, and that responses spanning several 8192 byte
+ * socket chunks still resolve. No Tauri app required.
+ *
+ * Run:  node test/reconnect-test.mjs
+ * (from mcp-server-ts/ directory, after `npm run build`)
+ */
+
+import net from "node:net";
+import { TauriSocketClient } from "../build/tools/client.js";
+
+// Large enough to span three socket chunks, which is what a duplicated data
+// listener corrupts. Anything under 8192 bytes arrives in one chunk and passes
+// even when the client is in the broken state.
+const PAYLOAD_BYTES = 20000;
+// The size the app's socket writes arrive in, and the boundary a duplicated
+// data listener corrupts. Loopback TCP would otherwise deliver the whole
+// response in one event and hide the bug.
+const CHUNK_BYTES = 8192;
+const COMMAND_TIMEOUT_MS = 5000;
+// The client's auto-reconnect fires 2 seconds after a close.
+const RECONNECT_DELAY_MS = 2500;
+
+let failures = 0;
+
+function check(name, condition, detail) {
+  if (condition) {
+    console.log(`PASS  ${name}`);
+  } else {
+    failures++;
+    console.log(`FAIL  ${name}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// ── Fake app socket ───────────────────────────────────────────────────
+
+const liveSockets = new Set();
+let peakConnections = 0;
+
+const server = net.createServer((socket) => {
+  liveSockets.add(socket);
+  peakConnections = Math.max(peakConnections, liveSockets.size);
+  socket.on("close", () => liveSockets.delete(socket));
+  socket.on("error", () => {});
+
+  let buffer = "";
+  socket.on("data", async (chunk) => {
+    buffer += chunk.toString();
+    let newlineIndex;
+    while ((newlineIndex = buffer.indexOf("\n")) !== -1) {
+      const line = buffer.substring(0, newlineIndex);
+      buffer = buffer.substring(newlineIndex + 1);
+      const request = JSON.parse(line);
+      const response =
+        JSON.stringify({
+          success: true,
+          id: request.id,
+          data: { payload: "x".repeat(PAYLOAD_BYTES) },
+        }) + "\n";
+
+      // Write in chunks, spaced out so each one lands as its own data event.
+      for (let offset = 0; offset < response.length; offset += CHUNK_BYTES) {
+        if (socket.destroyed) return;
+        socket.write(response.substring(offset, offset + CHUNK_BYTES));
+        await sleep(5);
+      }
+    }
+  });
+});
+
+await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+const { port } = server.address();
+
+const client = new TauriSocketClient({ type: "tcp", host: "127.0.0.1", port });
+
+// ── 1. Overlapping connect() calls share one socket ───────────────────
+
+await Promise.all([client.connect(), client.connect(), client.connect()]);
+// Let the server finish accepting anything the client opened.
+await sleep(100);
+check(
+  "three concurrent connect() calls open one connection",
+  peakConnections === 1,
+  `server saw ${peakConnections} concurrent connections`
+);
+
+let response = await client.sendCommand("ping", {}, COMMAND_TIMEOUT_MS).catch((e) => e);
+check(
+  "multi-chunk response resolves after concurrent connects",
+  response?.payload?.length === PAYLOAD_BYTES,
+  response instanceof Error ? response.message : `got ${JSON.stringify(response).slice(0, 80)}`
+);
+
+// ── 2. A command lost to a drop fails fast instead of hanging ─────────
+
+for (const socket of liveSockets) socket.destroy();
+
+const startedAt = Date.now();
+response = await client.sendCommand("ping", {}, COMMAND_TIMEOUT_MS).catch((e) => e);
+const elapsed = Date.now() - startedAt;
+check(
+  "a command in flight when the connection drops rejects promptly",
+  response instanceof Error && elapsed < 1000,
+  response instanceof Error
+    ? `rejected after ${elapsed}ms: ${response.message}`
+    : "the command resolved, so it was answered by a socket that had closed"
+);
+
+// The auto-reconnect timer from the drop above fires while that command's own
+// connection is already up. It must not open a second socket.
+await sleep(RECONNECT_DELAY_MS);
+check(
+  "the auto-reconnect timer does not add a second connection",
+  peakConnections === 1,
+  `server saw ${peakConnections} concurrent connections`
+);
+
+// ── 3. The same holds after the auto-reconnect owns the connection ────
+
+for (const socket of liveSockets) socket.destroy();
+await sleep(RECONNECT_DELAY_MS);
+
+response = await client.sendCommand("ping", {}, COMMAND_TIMEOUT_MS).catch((e) => e);
+check(
+  "multi-chunk response resolves after an auto-reconnect",
+  response?.payload?.length === PAYLOAD_BYTES,
+  response instanceof Error ? response.message : `got ${JSON.stringify(response).slice(0, 80)}`
+);
+
+console.log(failures === 0 ? "\nAll reconnect checks passed" : `\n${failures} check(s) failed`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
Fixes #33.

Two overlapping connect() calls could leave a single socket carrying both data listeners, which doubled every chunk in the shared buffer. Anything under 8192 bytes still parses, because the loop consumes the first copy, so this only showed up on take_screenshot and large query_page calls, which then hung for the full 30 second timeout. The race gets triggered in practice by the app restarting under tauri dev.

Listeners now bind to the socket the call created, one in-flight connect attempt is shared, and client state is cleared on close.

While testing I hit a second hang on the same path. A command sent in the window between the peer closing and the client seeing the close event gets written to a dead socket, and nothing ever settles it. Those requests now reject as soon as the socket closes, which restart_app has to read as an undelivered command rather than a refusal from the app, hence the one line change to its error classification.

test/reconnect-test.mjs stands up a fake app socket that answers in 8192 byte chunks, so it reproduces the failure with no Tauri app running. npm test runs it after the smoke test. All five checks fail on the current client and pass on this branch.

I left CHANGELOG.md alone since versions look like they get stamped at release time. Happy to add an entry if you would rather have one.
